### PR TITLE
Add info about body-parser to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 A thin library to create an express to elasticsearch proxy to support the searchkit ui framework
 
 ```sh
-npm install searchkit-express --save
+npm install searchkit-express body-parser --save
 ```
 
 ```js
 var SearchkitExpress = require("searchkit-express")
+var bodyParser = require('body-parser');
 ```
 
 #### Add _search endpoint to root url
@@ -38,6 +39,8 @@ const searchkit = new SearchkitManager("/")
 If you wish to get hold of an `express.Router` instance so you can configure the suburl and add specific express middleware; use as follows
 
 ```js
+var bodyParser = require('body-parser');
+
 var app = express()
 app.use(bodyParser.json())
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var createSearchkitRouter = function(config) {
   }
   router.post("/_search", function(req, res){
     var queryBody = config.queryProcessor(req.body || {}, req, res)
-    elasticRequest("/_search", queryBody).pipe(res)
+    elasticRequest("/_search?rest_total_hits_as_int=true", queryBody).pipe(res)
   });
 
   return router


### PR DESCRIPTION
Related to https://github.com/searchkit/searchkit-express/issues/11

This adds a bit of info to the README about installing `body-parser` and setting the `bodyParser` variable.